### PR TITLE
fix bogus tag

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8381,7 +8381,7 @@
       "locationSet": {"include": ["rs"]},
       "tags": {
         "amenity": "bank",
-        "barnd:en": "Postanska stedionica",
+        "brand:en": "Postanska stedionica",
         "brand": "Поштанска штедионица",
         "brand:sr": "Поштанска штедионица",
         "brand:sr-Latn": "Poštanska štedionica",


### PR DESCRIPTION
spotted while handling tags added by NSI in data analysis tool

maybe it would make sense to run an automated check on all tags added by NSI (check is there an OSM Wiki page with status other than deprecated, allow language suffixes for specific tags)